### PR TITLE
🐛(project) increase cell execution timeout

### DIFF
--- a/src/jupyterbook/_config.yml
+++ b/src/jupyterbook/_config.yml
@@ -10,6 +10,7 @@ logo: ""
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: force
+  timeout: 600 # 10 minutes cell execution timeout.
 
 # Define the name of the latex output file for PDF builds
 latex:


### PR DESCRIPTION
Jupyter cells performing GridSeach during jupyter-book build failed to
complete their execution due to the default 30 seconds timeout.
Therefore we decided to increase the execution timeout to 10 minutes.

We also update GridSearch usage in the notebooks to use all available CPU cores.