### PR TITLE
🐛(jupyterbook) fix plotly plot rendering in jupyterbook

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,14 +83,12 @@ clear-jupyter-book: ## remove the jupyter book build files
 .PHONY: clear-jupyter-book
 
 deploy-jupyter-book: \
-	clear-jupyter-book \
 	build-jupyter-book
 deploy-jupyter-book: ## deploy the jupyter book to gh-pages (with docker)
 	ghp-import -n -p -f src/jupyterbook/_build/html
 .PHONY: deploy-jupyter-book
 
 deploy-jupyter-book-venv: \
-	clear-jupyter-book \
 	build-jupyter-book-venv
 deploy-jupyter-book-venv: ## deploy the jupyter book to gh-pages (with venv)
 	@. venv/bin/activate && ghp-import -n -p -f src/jupyterbook/_build/html

--- a/src/jupyterbook/_config.yml
+++ b/src/jupyterbook/_config.yml
@@ -37,3 +37,8 @@ html:
   use_repository_button: true
 
 only_build_toc_files: true
+
+sphinx:
+  config:
+    html_js_files:
+    - https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.4/require.min.js

--- a/src/jupyterbook/_toc.yml
+++ b/src/jupyterbook/_toc.yml
@@ -11,3 +11,4 @@ chapters:
 - file: notebooks/optimize_mooc_learner_pathways
 - file: notebooks/time_series_classification_for_dropout_prediction
 - file: notebooks/withdrawal_prediction_on_behavioral_indicators
+- file: notebooks/detecting_at_risk_students

--- a/src/notebooks/detecting_at_risk_students.py
+++ b/src/notebooks/detecting_at_risk_students.py
@@ -43,9 +43,8 @@
 # :filter: docname in docnames
 # ```
 
-from shutil import rmtree
-
 # %%
+from shutil import rmtree
 from tempfile import mkdtemp
 
 import numpy as np


### PR DESCRIPTION
Plotly plots require the `require.js` dependency to display correctly.

We also remove the `clear-jupyter-book` make rule from `deploy-jupyter-book` to avoid rebuilding the entire jupyterbook on each deployment.

Add we add the missing `_toc` entry for the detecting at-risk students chapter.