### PR TITLE
🐛(project) rename CacheMagic with CaptureMagic

### DIFF
--- a/src/notebooks/detecting_at_risk_students.py
+++ b/src/notebooks/detecting_at_risk_students.py
@@ -69,10 +69,10 @@ from sklearn.preprocessing import PowerTransformer
 
 from oulad import get_oulad
 
-# %load_ext oulad.cache
+# %load_ext oulad.capture
 
 # %%
-# %%cache oulad
+# %%capture oulad
 oulad = get_oulad()
 
 # %% [markdown]
@@ -83,7 +83,7 @@ oulad = get_oulad()
 # Both the total sum of clicks and interaction frequency are computed.
 
 # %%
-# %%cache -ns detecting_at_risk_students feature_table
+# %%capture -ns detecting_at_risk_students feature_table
 feature_table = (
     oulad.vle.query("code_module == 'BBB' and code_presentation in ['2013B', '2013J']")
     .drop(columns=["code_module", "code_presentation"])
@@ -196,7 +196,7 @@ px.imshow(
 # In addition, the full `BBB_2013J` course dataset is employed as the validation set.
 
 # %%
-# %%cache -ns detecting_at_risk_students scores_roc_curves
+# %%capture -ns detecting_at_risk_students scores_roc_curves
 cachedir = mkdtemp()
 grid = {
     GradientBoostingClassifier: {

--- a/src/notebooks/first_descriptive_analysis.py
+++ b/src/notebooks/first_descriptive_analysis.py
@@ -32,10 +32,10 @@ import pandas as pd
 
 from oulad import get_oulad
 
-# %reload_ext oulad.cache
+# %reload_ext oulad.capture
 
 # %%
-# %%cache oulad
+# %%capture oulad
 oulad = get_oulad()
 
 # %% [markdown]

--- a/src/notebooks/identifying_key_milestones.py
+++ b/src/notebooks/identifying_key_milestones.py
@@ -54,10 +54,10 @@ from scipy.stats import levene, norm, probplot, ranksums, shapiro
 
 from oulad import get_oulad
 
-# %load_ext oulad.cache
+# %load_ext oulad.capture
 
 # %%
-# %%cache oulad
+# %%capture oulad
 oulad = get_oulad()
 
 # %% [markdown]

--- a/src/notebooks/optimize_mooc_learner_pathways.py
+++ b/src/notebooks/optimize_mooc_learner_pathways.py
@@ -48,7 +48,7 @@ from multicons import MultiCons
 
 from oulad import filter_by_module_presentation, get_oulad
 
-# %load_ext oulad.cache
+# %load_ext oulad.capture
 
 # %% [markdown]
 # ## Preparing the dataset
@@ -61,7 +61,7 @@ from oulad import filter_by_module_presentation, get_oulad
 # ### Loading OULAD
 
 # %%
-# %%cache oulad
+# %%capture oulad
 oulad = get_oulad()
 
 # %% [markdown]
@@ -82,7 +82,7 @@ CODE_PRESENTATION = "2013J"
 # session.
 
 # %%
-# %%cache -ns optimize_mooc_learner_pathways student_registration student_item
+# %%capture -ns optimize_mooc_learner_pathways student_registration student_item
 student_registration = (
     filter_by_module_presentation(
         oulad.student_registration, CODE_MODULE, CODE_PRESENTATION
@@ -199,7 +199,7 @@ x_train, x_test, y_train, y_test = train_test_split(
 # recommendations.
 
 # %%
-# %%cache -ns optimize_mooc_learner_pathways gs_classifier
+# %%capture -ns optimize_mooc_learner_pathways gs_classifier
 # Hyperparameter search space
 hyperparameters = {
     "criterion": ["gini"],  # ["gini", "entropy", "log_loss"],
@@ -249,7 +249,7 @@ display(
 # Consensus algorithm.
 
 # %%
-# %%cache -ns optimize_mooc_learner_pathways base_clusterings consensus
+# %%capture -ns optimize_mooc_learner_pathways base_clusterings consensus
 base_clusterings = [
     KMeans(
         n_clusters=18, max_iter=4000, n_init="auto", random_state=RANDOM_STATE
@@ -302,7 +302,7 @@ display(
 
 
 # %%
-# %%cache -ns optimize_mooc_learner_pathways recommenders_mc
+# %%capture -ns optimize_mooc_learner_pathways recommenders_mc
 def get_trained_recommenders(labels, algo, parameters) -> dict:
     """Returns a dictionary of trained recommenders by label."""
     recommenders = {}
@@ -336,7 +336,7 @@ recommenders_mc = get_trained_recommenders(consensus.labels_, KNNWithMeans, para
 
 
 # %%
-# %%cache -ns optimize_mooc_learner_pathways results_mc
+# %%capture -ns optimize_mooc_learner_pathways results_mc
 def get_recommendation_results(labels, recommenders):
     """Returns the percentages of succeeding students by recommendation count."""
     final_result_predictions = []
@@ -390,7 +390,7 @@ display(recommendation_improvement_rate_mc_cf_df)
 # collaborative filtering on the full dataset.
 
 # %%
-# %%cache -ns optimize_mooc_learner_pathways recommenders_cf results_cf
+# %%capture -ns optimize_mooc_learner_pathways recommenders_cf results_cf
 single_cluster = np.zeros(student_profile.shape[0])
 recommenders_cf = get_trained_recommenders(single_cluster, KNNWithMeans, param_grid)
 results_cf = get_recommendation_results(single_cluster, recommenders_cf)

--- a/src/notebooks/predicting_students_final_exam_outcome.py
+++ b/src/notebooks/predicting_students_final_exam_outcome.py
@@ -45,11 +45,11 @@ from multicons import MultiCons
 
 from oulad import filter_by_module_presentation, get_oulad
 
-# %load_ext oulad.cache
+# %load_ext oulad.capture
 
 
 # %%
-# %%cache oulad
+# %%capture oulad
 oulad = get_oulad()
 
 # %% [markdown]
@@ -71,7 +71,7 @@ oulad = get_oulad()
 
 
 # %%
-# %%cache -ns predicting_students_final_exam_outcome feature_table
+# %%capture -ns predicting_students_final_exam_outcome feature_table
 
 
 def get_feature_table(max_date=500, code_presentation="2013J"):
@@ -329,7 +329,7 @@ display(x_train)
 # search phase.
 
 # %%
-# %%cache -ns predicting_students_final_exam_outcome gs_scores
+# %%capture -ns predicting_students_final_exam_outcome gs_scores
 # Hyperparameter search space
 
 classifier_hyperparameters = {
@@ -455,7 +455,7 @@ oulad.assessments[
 
 
 # %%
-# %%cache -ns predicting_students_final_exam_outcome scores
+# %%capture -ns predicting_students_final_exam_outcome scores
 def get_train_test_assessments_by_day(day):
     """Returns the train/test feature table filtered by date."""
 

--- a/src/notebooks/tables.py
+++ b/src/notebooks/tables.py
@@ -22,10 +22,10 @@ from IPython.display import display
 
 from oulad import get_oulad
 
-# %load_ext oulad.cache
+# %load_ext oulad.capture
 
 # %%
-# %%cache oulad
+# %%capture oulad
 # Load the OULAD dataset in memory.
 oulad = get_oulad()
 

--- a/src/notebooks/time_series_classification_for_dropout_prediction.py
+++ b/src/notebooks/time_series_classification_for_dropout_prediction.py
@@ -50,10 +50,10 @@ from sklearn.model_selection import cross_val_score
 
 from oulad import get_oulad
 
-# %load_ext oulad.cache
+# %load_ext oulad.capture
 
 # %%
-# %%cache oulad
+# %%capture oulad
 oulad = get_oulad()
 
 # %% [markdown]
@@ -109,7 +109,7 @@ display(
 # as described in the work of Liu et al.
 
 # %%
-# %%cache -ns time_series_classification_for_dropout_prediction click_stream
+# %%capture -ns time_series_classification_for_dropout_prediction click_stream
 click_stream = (
     # 1. Extract the number of clicks by students on the three types of material.
     oulad.vle.query("activity_type in ['resource', 'oucontent', 'forumng']")
@@ -171,7 +171,7 @@ display(
 
 
 # %%
-# %%cache -ns time_series_classification_for_dropout_prediction results
+# %%capture -ns time_series_classification_for_dropout_prediction results
 def get_scores_by_activity_type() -> Iterator[list[float]]:
     """Computes accuracy prediction scores for each course."""
     for levels, course_df in click_stream.groupby(
@@ -211,7 +211,7 @@ display(results)
 
 
 # %%
-# %%cache -ns time_series_classification_for_dropout_prediction a_scores c_scores
+# %%capture -ns time_series_classification_for_dropout_prediction a_scores c_scores
 def get_score_by_slice(index_slice) -> Iterator[float]:
     """Computes accuracy prediction scores for the given `index_slice`."""
     y = click_stream.loc[index_slice, "final_result"].values

--- a/src/notebooks/withdrawal_prediction_on_behavioral_indicators.py
+++ b/src/notebooks/withdrawal_prediction_on_behavioral_indicators.py
@@ -38,10 +38,10 @@ from sklearn.tree import DecisionTreeClassifier
 
 from oulad import filter_by_module_presentation, get_oulad
 
-# %load_ext oulad.cache
+# %load_ext oulad.capture
 
 # %%
-# %%cache oulad
+# %%capture oulad
 oulad = get_oulad()
 
 # %% [markdown]
@@ -79,7 +79,7 @@ display(student_assessments)
 # ### Student course interactions table
 
 # %%
-# %%cache -ns withdrawal_prediction_on_behavioral_indicators student_vle
+# %%capture -ns withdrawal_prediction_on_behavioral_indicators student_vle
 student_vle = (
     filter_by_module_presentation(oulad.student_vle, MODULE, PRESENTATION)
     .merge(filter_by_module_presentation(oulad.vle, MODULE, PRESENTATION), on="id_site")
@@ -294,7 +294,7 @@ display(performance)
 # ### Elbow method
 
 # %%
-# %%cache -ns withdrawal_prediction_on_behavioral_indicators inertia
+# %%capture -ns withdrawal_prediction_on_behavioral_indicators inertia
 indicators = {
     "Perseverance indicator": perseverance,
     "Autonomy indicator": autonomy,
@@ -427,7 +427,7 @@ x_resampled, y_resampled = smote.fit_resample(x_train, y_train)
 # ```
 
 # %%
-# %%cache -ns withdrawal_prediction_on_behavioral_indicators scores
+# %%capture -ns withdrawal_prediction_on_behavioral_indicators scores
 grid = {
     DecisionTreeClassifier: {
         "unbalanced": {

--- a/src/oulad/capture.py
+++ b/src/oulad/capture.py
@@ -1,4 +1,4 @@
-"""Cache IPython magic implementation."""
+"""Capture cache IPython magic implementation."""
 
 import ast
 from pathlib import Path
@@ -14,8 +14,8 @@ from IPython.core.magic import (
 
 
 @magics_class
-class CacheMagic(Magics):
-    """The %%cache magic function caches variable values by name and namespace."""
+class CaptureMagic(Magics):
+    """The %%capture magic function caches variable values by name and namespace."""
 
     @magic_arguments.magic_arguments()
     @magic_arguments.argument("variables", nargs="+")
@@ -29,17 +29,22 @@ class CacheMagic(Magics):
     @needs_local_scope
     @no_var_expand
     @cell_magic
-    def cache(self, line, cell, local_ns):
-        """Cache the values of variables from the cell by namespace.
+    def capture(self, line, cell, local_ns):
+        """Capture (cache) the values of variables from the cell by namespace.
 
         Usage:
-          %%cache [-ns<N>] var1 var2 ...
+          %%capture [-ns<N>] var1 var2 ...
 
         Parameters:
           -ns<N> (str): a namespace string key to cache the values. The combination of
               the namespace and a variable name should be unique.
+
+        Note:
+            `cache` would be an more appropriate name for this method, however, IPython
+            lexer doesn't support syntax highlighting for custom magics, thus we
+            overwrite the existing `capture` magic for now.
         """
-        args = magic_arguments.parse_argstring(self.cache, line)
+        args = magic_arguments.parse_argstring(self.capture, line)
         cache_dir = Path.home() / ".cache/oulad"
         cache_dir.mkdir(parents=True, exist_ok=True)
         cell_ast = ast.parse(cell)
@@ -73,7 +78,7 @@ class CacheMagic(Magics):
 
         # pylint: disable=exec-used
         exec("import pickle", local_ns)  # nosec
-        exec(compile(cell_ast, "<magic-cache>", "exec"), local_ns)  # nosec
+        exec(compile(cell_ast, "<magic-capture>", "exec"), local_ns)  # nosec
 
 
 def load_ipython_extension(ipython):
@@ -82,4 +87,4 @@ def load_ipython_extension(ipython):
     can be loaded via `%load_ext module.path` or be configured to be
     autoloaded by IPython at startup time.
     """
-    ipython.register_magics(CacheMagic)
+    ipython.register_magics(CaptureMagic)


### PR DESCRIPTION
Although CacheMagic would be a more appropriate name for the IPython magic command class that caches cell variables, unfortunately, the IPython lexer doesn't support syntax highlighting for custom magic commands for now. Thus, we choose to rename CacheMagic with CaptureMagic and %%cache with %%capture - overwriting the existing %%capture magic command with our implementation.